### PR TITLE
Launch langchain job to check MCP access

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,25 @@ async with stdio_client(server_params) as (read, write):
         agent_response = await agent.ainvoke({"messages": "what's (3 + 5) x 12?"})
 ```
 
+### Run quick connectivity probes (no API key required)
+
+Run a local stdio MCP server and probe it:
+
+```bash
+python3 /workspace/scripts/probe_mcp.py
+```
+
+Run a local Streamable HTTP MCP server and probe it:
+
+```bash
+# in one shell
+cd /workspace/examples/servers/streamable-http-stateless
+python3 -m mcp_simple_streamablehttp_stateless --port 3010
+
+# in another shell
+python3 /workspace/scripts/probe_mcp_http.py
+```
+
 ## Multiple MCP Servers
 
 The library also allows you to connect to multiple MCP servers and load tools from them:

--- a/scripts/probe_mcp.py
+++ b/scripts/probe_mcp.py
@@ -1,0 +1,49 @@
+import asyncio
+import os
+from pathlib import Path
+
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+
+async def main() -> int:
+    tests_dir = Path(__file__).resolve().parents[1] / "tests" / "servers"
+    math_server_path = str(tests_dir / "math_server.py")
+
+    if not os.path.exists(math_server_path):
+        print(f"Math server not found at: {math_server_path}")
+        return 2
+
+    client = MultiServerMCPClient(
+        {
+            "math": {
+                "transport": "stdio",
+                "command": "python3",
+                "args": [math_server_path],
+            }
+        }
+    )
+
+    print("Listing tools from MCP 'math' server...")
+    tools = await client.get_tools(server_name="math")
+    for tool in tools:
+        print(f"- {tool.name}: {tool.description}")
+
+    # Try calling tools if present
+    tool_names = {t.name for t in tools}
+    if {"add", "multiply"}.issubset(tool_names):
+        add_tool = next(t for t in tools if t.name == "add")
+        multiply_tool = next(t for t in tools if t.name == "multiply")
+        add_result = await add_tool.ainvoke({"a": 2, "b": 3})
+        mul_result = await multiply_tool.ainvoke({"a": 4, "b": 5})
+        print(f"add(2,3) -> {add_result}")
+        print(f"multiply(4,5) -> {mul_result}")
+        print("MCP connectivity OK")
+        return 0
+
+    print("MCP connected but expected tools not found.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))
+

--- a/scripts/probe_mcp_http.py
+++ b/scripts/probe_mcp_http.py
@@ -1,0 +1,39 @@
+import asyncio
+
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+
+async def main() -> int:
+    url = "http://127.0.0.1:3010/mcp/"
+    client = MultiServerMCPClient(
+        {
+            "math_http": {
+                "transport": "streamable_http",
+                "url": url,
+            }
+        }
+    )
+
+    print(f"Listing tools from MCP server at {url}...")
+    tools = await client.get_tools(server_name="math_http")
+    for tool in tools:
+        print(f"- {tool.name}: {tool.description}")
+
+    tool_names = {t.name for t in tools}
+    if {"add", "multiply"}.issubset(tool_names):
+        add_tool = next(t for t in tools if t.name == "add")
+        multiply_tool = next(t for t in tools if t.name == "multiply")
+        add_result = await add_tool.ainvoke({"a": 7, "b": 8})
+        mul_result = await multiply_tool.ainvoke({"a": 6, "b": 7})
+        print(f"add(7,8) -> {add_result}")
+        print(f"multiply(6,7) -> {mul_result}")
+        print("MCP streamable HTTP connectivity OK")
+        return 0
+
+    print("MCP connected but expected tools not found.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))
+


### PR DESCRIPTION
Add `scripts/probe_mcp.py` to verify LangChain's connectivity to the MCP by launching a local math server and calling its tools.

---
<a href="https://cursor.com/background-agent?bcId=bc-80c87724-8e5a-48ed-b11b-fb3582f53f9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-80c87724-8e5a-48ed-b11b-fb3582f53f9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

